### PR TITLE
Autoprefix CSS

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -69,12 +69,12 @@ module.exports = function (grunt) {
         processors: [
           require('autoprefixer')({
             browsers: [
-              'Chrome >= ' + settings.browsers.Chrome,
-              'Firefox >= ' + settings.browsers.Firefox,
-              'Edge >= ' + settings.browsers.Edge,
-              'Explorer >= ' + settings.browsers.Explorer,
-              'Safari >= ' + settings.browsers.Safari,
-              'Opera >= ' + settings.browsers.Opera
+              'Chrome = ' + settings.browsers.Chrome,
+              'Firefox = ' + settings.browsers.Firefox,
+              'Edge = ' + settings.browsers.Edge,
+              'Explorer = ' + settings.browsers.Explorer,
+              'Safari = ' + settings.browsers.Safari,
+              'Opera = ' + settings.browsers.Opera
             ]
           })
         ],

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -77,8 +77,8 @@ module.exports = function (grunt) {
               'Opera >= ' + settings.Browsers.Opera
             ]
           })
-		],
-		src: 'src/scss/css/' + element + '.css',
+        ],
+        src: 'src/scss/css/' + element + '.css',
       }]);
 
       grunt.task.run('postcss:' + element);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -63,18 +63,18 @@ module.exports = function (grunt) {
 
       grunt.task.run('sass:' + element);
 
-	  // Autoprefix the CSS files
+      // Autoprefix the CSS files
       grunt.config.set('postcss.' + element + '.files', [{
         map: false,
         processors: [
           require('autoprefixer')({
             browsers: [
-              'Chrome >= ' + settings.Browsers.Chrome,
-              'Firefox >= ' + settings.Browsers.Firefox,
-              'Edge >= ' + settings.Browsers.Edge,
-              'Explorer >= ' + settings.Browsers.Explorer,
-              'Safari >= ' + settings.Browsers.Safari,
-              'Opera >= ' + settings.Browsers.Opera
+              'Chrome >= ' + settings.browsers.Chrome,
+              'Firefox >= ' + settings.browsers.Firefox,
+              'Edge >= ' + settings.browsers.Edge,
+              'Explorer >= ' + settings.browsers.Explorer,
+              'Safari >= ' + settings.browsers.Safari,
+              'Opera >= ' + settings.browsers.Opera
             ]
           })
         ],

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -78,7 +78,7 @@ module.exports = function (grunt) {
             ]
           })
         ],
-        src: 'src/scss/css/' + element + '.css',
+        src: 'src/scss/css/' + element + '.css'
       }]);
 
       grunt.task.run('postcss:' + element);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -78,7 +78,7 @@ module.exports = function (grunt) {
             ]
           })
         ],
-        src: 'src/scss/css/' + element + '.css'
+        src: 'src/scss/css/' + element + '.css',
       }]);
 
       grunt.task.run('postcss:' + element);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -9,6 +9,7 @@ module.exports = function (grunt) {
   }
 
   // Load required modules
+  grunt.loadNpmTasks('grunt-postcss');
   grunt.loadNpmTasks('grunt-sass');
   grunt.loadNpmTasks('grunt-contrib-cssmin');
   grunt.loadNpmTasks('grunt-babel');
@@ -53,8 +54,8 @@ module.exports = function (grunt) {
 
   // Compile the css
   grunt.registerTask('compile', 'Compile css files', function () {
-    // Compile the css files
     var compileCss = function (element) {
+      // Compile the css files
       grunt.config.set('sass.' + element + '.files', [{
         src: 'src/scss/' + element + '/' + element + '.scss',
         dest: 'src/scss/css/' + element + '.css'
@@ -62,6 +63,27 @@ module.exports = function (grunt) {
 
       grunt.task.run('sass:' + element);
 
+	  // Autoprefix the CSS files
+      grunt.config.set('postcss.' + element + '.files', [{
+        map: false,
+        processors: [
+          require('autoprefixer')({
+            browsers: [
+              'Chrome >= ' + settings.Browsers.Chrome,
+              'Firefox >= ' + settings.Browsers.Firefox,
+              'Edge >= ' + settings.Browsers.Edge,
+              'Explorer >= ' + settings.Browsers.Explorer,
+              'Safari >= ' + settings.Browsers.Safari,
+              'Opera >= ' + settings.Browsers.Opera
+            ]
+          })
+		],
+		src: 'src/scss/css/' + element + '.css',
+      }]);
+
+      grunt.task.run('postcss:' + element);
+
+      // Autoprefix the CSS files
       grunt.config.set('cssmin.' + element + '.files', [{
         src: 'src/scss/css/' + element + '.css',
         dest: 'src/scss/css/' + settings.prefix + '-' + element + '.min.css'

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   ],
   "author": "Dimitrios Grammatikogiannis, Charlie Lodder",
   "devDependencies": {
+    "autoprefixer": "^7.1.3",
     "@polymer/test-fixture": "latest",
     "@webcomponents/custom-elements": "latest",
     "@webcomponents/webcomponentsjs": "latest",
@@ -43,6 +44,7 @@
     "grunt-contrib-uglify": "git://github.com/gruntjs/grunt-contrib-uglify.git#harmony",
     "grunt-sass": "latest",
     "grunt-shell": "latest",
+    "grunt-postcss": "latest",
     "web-component-tester": "latest",
     "webcomponentsjs": "latest",
     "eslint": "latest",

--- a/settings.yaml
+++ b/settings.yaml
@@ -1,20 +1,29 @@
 #### Override this file by adding a setting-custom.yaml in the root folder (next to settings.yaml file)
 #### Prefix is used to customize the elements, eg yupee will produce: yupee-alert, yupee-modal, etc
 #### Comment out the elements you don't want to be created
-'prefix'   : 'joomla'
-'elements':
-            # - 'accordion'
-            - 'alert'
-            # - 'group-buttons'
-            # - 'collapse'
-            # - 'dropdown'
-            # - 'modal'
-            # - 'popover'
-            # - 'password'
-            # - 'switcher'
-            - 'tab'
-            - 'field-media'
-            - 'field-send-mail'
-            # - 'tooltip'
 
-## - 'popover' Use css for this
+'prefix':
+    'joomla'
+
+'elements':
+    # - 'accordion'
+    - 'alert'
+    # - 'group-buttons'
+    # - 'collapse'
+    # - 'dropdown'
+    # - 'modal'
+    # - 'popover'
+    # - 'password'
+    # - 'switcher'
+    - 'tab'
+    - 'field-media'
+    - 'field-send-mail'
+    # - 'tooltip'
+
+'browsers':
+    'Chrome':   'last 1 version'
+    'Firefox':  'last 1 version'
+    'Edge':     'last 1 version'
+    'Explorer': '11'
+    'Safari':   'last 1 version'
+    'Opera':    'last 1 version'

--- a/settings.yaml
+++ b/settings.yaml
@@ -24,6 +24,6 @@
     'Chrome':   'last 1 version'
     'Firefox':  'last 1 version'
     'Edge':     'last 1 version'
-    'Explorer': '11'
+    'Explorer': 'last 1 version'
     'Safari':   'last 1 version'
     'Opera':    'last 1 version'


### PR DESCRIPTION
Add the following to one of the SCSS files:

```
transform: translateY(50%);
```

Then check the compiled CSS inside the JS file and you should see the prefixed CSS:

```
-webkit-transform: translateY(50%);
-ms-transform: translateY(50%);
transform: translateY(50%);
```