### PR TITLE
Make role attribute configurable

### DIFF
--- a/src/js/alert/alert.js
+++ b/src/js/alert/alert.js
@@ -1,11 +1,15 @@
 (() => {
   class JoomlaAlertElement extends HTMLElement {
     /* Attributes to monitor */
-    static get observedAttributes() { return ['type', 'dismiss', 'acknowledge', 'href']; }
+    static get observedAttributes() { return ['type', 'role', 'dismiss', 'acknowledge', 'href']; }
 
     get type() { return this.getAttribute('type'); }
 
     set type(value) { return this.setAttribute('type', value); }
+
+    get role() { return this.getAttribute('role'); }
+
+    set role(value) { return this.setAttribute('role', value); }
 
     get dismiss() { return this.getAttribute('dismiss'); }
 
@@ -15,12 +19,15 @@
 
     /* Lifecycle, element appended to the DOM */
     connectedCallback() {
-      this.setAttribute('role', 'alertdialog');
       this.classList.add('joomla-alert--show');
 
       // Default to info
       if (!this.type || ['info', 'warning', 'danger', 'success'].indexOf(this.type) === -1) {
         this.setAttribute('type', 'info');
+      }
+      // Default to alert
+      if (!this.role || ['alert', 'alertdialog'].indexOf(this.role) === -1) {
+        this.setAttribute('role', 'alert');
       }
       // Append button
       if ((this.hasAttribute('dismiss') || this.hasAttribute('acknowledge')) || ((this.hasAttribute('href') && this.getAttribute('href') !== '')
@@ -54,6 +61,11 @@
         case 'type':
           if (!newValue || (newValue && ['info', 'warning', 'danger', 'success'].indexOf(newValue) === -1)) {
             this.type = 'info';
+          }
+          break;
+        case 'role':
+          if (!newValue || (newValue && ['alert', 'alertdialog'].indexOf(newValue) === -1)) {
+            this.role = 'alert';
           }
           break;
         case 'dismiss':


### PR DESCRIPTION
Fix issue #118 

Now it is possible to specify a `role` attribute of `alert` or `alertdialog`. If no `role` attribute, then default to `alert`.

For example
`<joomla-alert type="info" dismiss="true" class="js-pstats-alert" style="display:none;" role="alertdialog">`

@C-Lodder  Please review code or should be done differently. Thanks.