### PR TITLE
ALERT element - remove the focus

### DIFF
--- a/src/js/alert/alert.js
+++ b/src/js/alert/alert.js
@@ -30,8 +30,6 @@
 
       this.dispatchCustomEvent('joomla.alert.show');
 
-      const closeButton = this.querySelector('button.joomla-alert--close') || this.querySelector('button.joomla-alert-button--close');
-
     }
 
     /* Lifecycle, element removed from the DOM */

--- a/src/js/alert/alert.js
+++ b/src/js/alert/alert.js
@@ -29,7 +29,6 @@
       }
 
       this.dispatchCustomEvent('joomla.alert.show');
-
     }
 
     /* Lifecycle, element removed from the DOM */

--- a/src/js/alert/alert.js
+++ b/src/js/alert/alert.js
@@ -32,9 +32,6 @@
 
       const closeButton = this.querySelector('button.joomla-alert--close') || this.querySelector('button.joomla-alert-button--close');
 
-      if (closeButton) {
-        closeButton.focus();
-      }
     }
 
     /* Lifecycle, element removed from the DOM */


### PR DESCRIPTION
This is part1 of a fix for https://github.com/joomla/joomla-cms/issues/25348

We should not be changing the focus to the alert element. If we do then that forces the user to close the alert and they have lost their place in the document. 

Part2 which will be in the core layout is to add the attribute aria-live to the message container. This will ensure that the message will be announced by the screenreader even though we don't give it focus