### PR TITLE
[alert] Move parseInt() wrapper

### DIFF
--- a/src/js/alert/alert.js
+++ b/src/js/alert/alert.js
@@ -157,7 +157,7 @@
           } else {
             self.close();
           }
-        }, parseInt(self.getAttribute('auto-dismiss'), 10) ? self.getAttribute('auto-dismiss') : 3000);
+        }, self.getAttribute('auto-dismiss') ? parseInt(self.getAttribute('auto-dismiss'), 10) : 3000);
       }
     }
 


### PR DESCRIPTION
Wrap `parseInt(xxx, 10)` around the code that's actually excuted....not the check