### PR TITLE
Fix tabLink is null

### DIFF
--- a/src/js/tab/tab.js
+++ b/src/js/tab/tab.js
@@ -273,7 +273,7 @@
     }
 
     showTab(tab) {
-      const tabLink = document.querySelector(`#tab-${tab.id}`);
+      const tabLink = document.querySelector(`#${tab.id}`);
       tabLink.click();
     }
 


### PR DESCRIPTION
Fix https://github.com/joomla/joomla-cms/issues/25359

`tab.id` value is `content`
`#tab-${tab.id}` = `#tab-content` (not found)
`#${tab.id}` = `#content` (found)

`<section id="content" class="content">`
