### PR TITLE
aria hidden

### DIFF
--- a/src/js/tab/tab.js
+++ b/src/js/tab/tab.js
@@ -137,6 +137,7 @@
       // Fallback if no active tab
       if (!this.hasActive) {
         tabsEl[0].setAttribute('active', '');
+        tabsEl[0].removeAttribute('aria-hidden');
         this.hasActive = true;
         this.currentActive = tabsEl[0].id;
         this.querySelector(`#tab-${tabsEl[0].id}`).setAttribute('aria-selected', 'true');


### PR DESCRIPTION
when there is no active tab set we need to remove the attribute aria-hidden. Other wise the tab is invisible to a screen reader

PR for https://github.com/joomla/joomla-cms/issues/28122

obviously this will need a new release after merging