### PR TITLE
Add support for prefers-reduced-motion in alerts

### DIFF
--- a/src/js/alert/alert.js
+++ b/src/js/alert/alert.js
@@ -103,13 +103,10 @@
     /* Method to close the alert */
     close(element = null) {
       this.dispatchCustomEvent('joomla.alert.close');
-      if (window.matchMedia('(prefers-reduced-motion)').matches)
-      {
-        markAlertClosed(element);
-      }
-      else
-      {
-        this.addEventListener('transitionend', () => markAlertClosed(element), false);
+      if (window.matchMedia('(prefers-reduced-motion)').matches) {
+        this.markAlertClosed(element);
+      } else {
+        this.addEventListener('transitionend', () => this.markAlertClosed(element), false);
       }
       this.classList.remove('joomla-alert--show');
     }

--- a/src/js/alert/alert.js
+++ b/src/js/alert/alert.js
@@ -91,17 +91,26 @@
       }
     }
 
-    /* Method to close the alert */
-    close(element = null) {
-      this.dispatchCustomEvent('joomla.alert.close');
-      this.addEventListener('transitionend', () => {
+    markAlertClosed() {
         this.dispatchCustomEvent('joomla.alert.closed');
         if (element) {
           element.parentNode.removeChild(element);
         } else {
           this.remove();
         }
-      }, false);
+    }
+
+    /* Method to close the alert */
+    close(element = null) {
+      this.dispatchCustomEvent('joomla.alert.close');
+      if (window.matchMedia('(prefers-reduced-motion)').matches)
+      {
+        this.addEventListener('transitionend', () => markAlertClosed, false);
+      }
+      else
+      {
+        markAlertClosed()
+      }
       this.classList.remove('joomla-alert--show');
     }
 

--- a/src/js/alert/alert.js
+++ b/src/js/alert/alert.js
@@ -91,13 +91,13 @@
       }
     }
 
-    markAlertClosed() {
-        this.dispatchCustomEvent('joomla.alert.closed');
-        if (element) {
-          element.parentNode.removeChild(element);
-        } else {
-          this.remove();
-        }
+    markAlertClosed(element) {
+      this.dispatchCustomEvent('joomla.alert.closed');
+      if (element) {
+        element.parentNode.removeChild(element);
+      } else {
+        this.remove();
+      }
     }
 
     /* Method to close the alert */
@@ -105,11 +105,11 @@
       this.dispatchCustomEvent('joomla.alert.close');
       if (window.matchMedia('(prefers-reduced-motion)').matches)
       {
-        this.addEventListener('transitionend', () => markAlertClosed, false);
+        markAlertClosed(element);
       }
       else
       {
-        markAlertClosed()
+        this.addEventListener('transitionend', () => markAlertClosed(element), false);
       }
       this.classList.remove('joomla-alert--show');
     }


### PR DESCRIPTION
Description stolen from @brianteeman 's original description in https://github.com/joomla-projects/custom-elements/pull/138 which originally alerted me to this (thankyou!)

Resolves a release blocker in the cms https://github.com/joomla/joomla-cms/issues/25850


When you close an alert the code in this js should do two things

1. remove the element
2. remove the class 'joomla=alert--show' from the alert

However if you have enabled prefers reduced motion on your computer then  the first of those never happens because it is based on a transition that is disabled by prefers-reduced-motion.

This results in an invisible div sitting on top of the toolbar which prevents you from being able to click on the toolbar. It also means that if you have multiple alerts and close the one in the middle you are left with a gap on the screen.


Easiest way to test would be to first 

### replicate the issue

On your test computer locate the setting for animations and make sure animations are off..
- In Windows 10: Settings > Ease of Access > Display > Show animations in Windows.
- In macOS: System Preferences > Accessibility > Display > Reduce motion.

Do anything that will trigger an alert eg save
inspect the alert
Note the class on the `joomla-alert` and the contents of the alert
dismiss/close the alert
Note the class on the `joomla-alert` has been removed but the contents of the alert remain

turn animations back on and repeat. this time you will see
the entire contents of the `system-message-container` have been removed.

### Test the patch
1. apply the code here to media\vendor\joomla-custom-elements\js\joomla-alert.js in your joomla install and with debug mode on to ensure the minified js you just edited is being used repeat the tests
Now you will see  the entire contents of the `system-message-container` have been removed in BOTH cases.