### PR TITLE
Attempt to only run WCT if the username PR is set

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_script:
 - bower install
 script:
 - eslint src
-- if [ -z ${SAUCE_USERNAME} ]; then wct --configFile saucelabs.conf.json --plugin sauce; fi
+- if [[ ! -z ${SAUCE_USERNAME} ]]; then wct --configFile saucelabs.conf.json --plugin sauce; fi
 notifications:
   email: false
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_script:
 - bower install
 script:
 - eslint src
-- wct --configFile saucelabs.conf.json --plugin sauce
+- if [ -z ${SAUCE_USERNAME} ]; then wct --configFile saucelabs.conf.json --plugin sauce; fi
 notifications:
   email: false
 addons:


### PR DESCRIPTION
WCT can't be run of foreign PRs because of https://docs.travis-ci.com/user/pull-requests#pull-requests-and-security-restrictions

TODO: Move to Drone as the signature will prevent this attack vector and thus always allow us to run WCT (Before @dgrammatiko comments - github actions don't have signatures either so would have same issue as travis ;) https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets#using-encrypted-secrets-in-a-workflow)