### PR TITLE
Use another script for removing the label

### DIFF
--- a/.github/workflows/remote-tests.yml
+++ b/.github/workflows/remote-tests.yml
@@ -39,7 +39,9 @@ jobs:
         SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
 
     # Remove the label
-    - uses: actions-ecosystem/action-remove-labels@v1
+    - name: removelabel
+      uses: buildsville/add-remove-label@v1
       with:
-        labels: |
-          runTests
+        token: ${{secrets.GITHUB_TOKEN}}
+        label: runTests
+        type: remove


### PR DESCRIPTION
- Tests are triggered by adding a label
- At the end of the tests we want the label to be removed (so if new code is pushed will not run unverified)
- This is using another script for this task
