### PR TITLE
Fixed Issue with createNavs and removeNavs Functions by Correcting .some() Method Usage

### DIFF
--- a/src/js/tab/tab.js
+++ b/src/js/tab/tab.js
@@ -303,7 +303,7 @@ class TabsElement extends HTMLElement {
 
   // Create navigation elements for inserted tabs
   createNavs(tab) {
-    if ((tab instanceof Element && tab.tagName.toLowerCase() !== 'joomla-tab-element') || ![].some.call(this.children, (el) => el === tab).length || !tab.getAttribute('name') || !tab.getAttribute('id')) return;
+    if ((tab instanceof Element && tab.tagName.toLowerCase() !== 'joomla-tab-element') || ![].some.call(this.children, (el) => el === tab) || !tab.getAttribute('name') || !tab.getAttribute('id')) return;
     const tabs = [].slice.call(this.children).filter((el) => el.tagName.toLowerCase() === 'joomla-tab-element');
     const index = tabs.findIndex((tb) => tb === tab);
 
@@ -359,7 +359,7 @@ class TabsElement extends HTMLElement {
 
   // Remove navigation elements for removed tabs
   removeNavs(tab) {
-    if ((tab instanceof Element && tab.tagName.toLowerCase() !== 'joomla-tab-element') || ![].some.call(this.children, (el) => el === tab).length || !tab.getAttribute('name') || !tab.getAttribute('id')) return;
+    if ((tab instanceof Element && tab.tagName.toLowerCase() !== 'joomla-tab-element') || ![].some.call(this.children, (el) => el === tab) || !tab.getAttribute('name') || !tab.getAttribute('id')) return;
     const accordionButton = tab.previousSilbingElement;
     if (accordionButton && accordionButton.tagName.toLowerCase() === 'button') {
       accordionButton.removeEventListener('click', this.keyBehaviour);


### PR DESCRIPTION
Fixes #240 
This pull request addresses the issue where the createNavs and removeNavs functions in the navigation system were not executing properly due to incorrect usage of the .some() method.

Changes Made:

Corrected .some() Method Usage:

Removed the .length property from the .some() method in the createNavs and removeNavs functions as .some() returns a boolean and not an array.